### PR TITLE
Recover panics in request handler dispatch

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"runtime"
 
 	xdr2 "github.com/rasky/go-xdr/xdr2"
 	"github.com/willscott/go-nfs-client/nfs/rpc"
@@ -20,6 +21,10 @@ var (
 	ErrInputInvalid = errors.New("invalid input")
 	// ErrAlreadySent is returned when writing a header/status multiple times
 	ErrAlreadySent = errors.New("response already started")
+	// ErrAbortHandler is a sentinel panic value to abort a handler.
+	// Panicking with ErrAbortHandler still returns a system error to
+	// the client, but suppresses logging of a stack trace.
+	ErrAbortHandler = errors.New("nfs: abort handler")
 )
 
 // ResponseCode is a combination of accept_stat and reject_stat.
@@ -122,7 +127,19 @@ func (c *conn) handle(ctx context.Context, w *response) error {
 		}
 		return c.err(ctx, w, &ResponseCodeProcUnavailableError{})
 	}
-	appError := handler(ctx, w, c.Server.Handler)
+	var appError error
+	func() {
+		defer func() {
+			if r := recover(); r != nil && r != ErrAbortHandler {
+				const size = 64 << 10
+				buf := make([]byte, size)
+				buf = buf[:runtime.Stack(buf, false)]
+				Log.Errorf("panic in handler for %v: %v\n%s", w.req, r, buf)
+				appError = &ResponseCodeSystemError{}
+			}
+		}()
+		appError = handler(ctx, w, c.Server.Handler)
+	}()
 	if drainErr := w.drain(ctx); drainErr != nil {
 		return drainErr
 	}


### PR DESCRIPTION
## Summary

Add panic recovery in `conn.handle()`, wrapping the handler dispatch call.
Same pattern as `net/http.Server`:

- Recover the panic
- Log the value and full stack trace via `Log.Errorf`
- Return `ResponseCodeSystemErr` to the NFS client for the failed request
- Keep the connection alive — the panic is isolated to the active request

Also adds `ErrAbortHandler`, a sentinel panic value that suppresses
logging (same as `net/http.ErrAbortHandler`).

## Motivation

When an NFS handler panics today, the `serve()` goroutine dies and the
connection drops. The panic message and stack trace are lost.

With this fix, the panic is caught, logged with a full stack trace,
and the NFS client gets a system error response instead of a dead connection.