### PR TITLE
feat: add RecoverPanics helper to wrap handler and filesystem

### DIFF
--- a/helpers/recovery.go
+++ b/helpers/recovery.go
@@ -17,13 +17,16 @@ type OnPanic func(any)
 // to ensure panics in the filesystem implementation are caught.
 func RecoverPanics(h nfs.Handler, onPanic OnPanic) nfs.Handler {
 	return &recoveryHandler{
-		Handler: h,
+		handler: h,
 		onPanic: onPanic,
 	}
 }
 
+// recoveryHandler wraps an nfs.Handler with panic recovery.
+// It uses explicit delegation (not embedding) so the compiler forces
+// us to implement any new methods added to the interface.
 type recoveryHandler struct {
-	nfs.Handler
+	handler nfs.Handler
 	onPanic OnPanic
 }
 
@@ -35,7 +38,7 @@ func (h *recoveryHandler) recover() {
 
 func (h *recoveryHandler) Mount(ctx context.Context, conn net.Conn, req nfs.MountRequest) (status nfs.MountStatus, hndl billy.Filesystem, auths []nfs.AuthFlavor) {
 	defer h.recover()
-	status, hndl, auths = h.Handler.Mount(ctx, conn, req)
+	status, hndl, auths = h.handler.Mount(ctx, conn, req)
 	if hndl != nil {
 		hndl = &recoveryFilesystem{Filesystem: hndl, onPanic: h.onPanic}
 	}
@@ -48,7 +51,7 @@ func (h *recoveryHandler) Change(fs billy.Filesystem) billy.Change {
 	if rf, ok := fs.(*recoveryFilesystem); ok {
 		fs = rf.Filesystem
 	}
-	return h.Handler.Change(fs)
+	return h.handler.Change(fs)
 }
 
 func (h *recoveryHandler) FSStat(ctx context.Context, fs billy.Filesystem, stat *nfs.FSStat) error {
@@ -56,7 +59,7 @@ func (h *recoveryHandler) FSStat(ctx context.Context, fs billy.Filesystem, stat 
 	if rf, ok := fs.(*recoveryFilesystem); ok {
 		fs = rf.Filesystem
 	}
-	return h.Handler.FSStat(ctx, fs, stat)
+	return h.handler.FSStat(ctx, fs, stat)
 }
 
 func (h *recoveryHandler) ToHandle(fs billy.Filesystem, path []string) []byte {
@@ -64,12 +67,12 @@ func (h *recoveryHandler) ToHandle(fs billy.Filesystem, path []string) []byte {
 	if rf, ok := fs.(*recoveryFilesystem); ok {
 		fs = rf.Filesystem
 	}
-	return h.Handler.ToHandle(fs, path)
+	return h.handler.ToHandle(fs, path)
 }
 
 func (h *recoveryHandler) FromHandle(fh []byte) (billy.Filesystem, []string, error) {
 	defer h.recover()
-	fs, path, err := h.Handler.FromHandle(fh)
+	fs, path, err := h.handler.FromHandle(fh)
 	if fs != nil {
 		fs = &recoveryFilesystem{Filesystem: fs, onPanic: h.onPanic}
 	}
@@ -81,12 +84,12 @@ func (h *recoveryHandler) InvalidateHandle(fs billy.Filesystem, fh []byte) error
 	if rf, ok := fs.(*recoveryFilesystem); ok {
 		fs = rf.Filesystem
 	}
-	return h.Handler.InvalidateHandle(fs, fh)
+	return h.handler.InvalidateHandle(fs, fh)
 }
 
 func (h *recoveryHandler) HandleLimit() int {
 	defer h.recover()
-	return h.Handler.HandleLimit()
+	return h.handler.HandleLimit()
 }
 
 // recoveryFilesystem wraps a billy.Filesystem with panic recovery.

--- a/helpers/recovery.go
+++ b/helpers/recovery.go
@@ -1,0 +1,183 @@
+package helpers
+
+import (
+	"context"
+	"net"
+	"os"
+
+	"github.com/go-git/go-billy/v6"
+	"github.com/treeverse/go-nfs"
+)
+
+// OnPanic is a function called when a panic is recovered.
+type OnPanic func(any)
+
+// RecoverPanics wraps a handler to recover from panics in its method calls.
+// It also wraps any billy.Filesystem returned by the handler's Mount or FromHandle methods
+// to ensure panics in the filesystem implementation are caught.
+func RecoverPanics(h nfs.Handler, onPanic OnPanic) nfs.Handler {
+	return &recoveryHandler{
+		Handler: h,
+		onPanic: onPanic,
+	}
+}
+
+type recoveryHandler struct {
+	nfs.Handler
+	onPanic OnPanic
+}
+
+func (h *recoveryHandler) recover() {
+	if r := recover(); r != nil {
+		h.onPanic(r)
+	}
+}
+
+func (h *recoveryHandler) Mount(ctx context.Context, conn net.Conn, req nfs.MountRequest) (status nfs.MountStatus, hndl billy.Filesystem, auths []nfs.AuthFlavor) {
+	defer h.recover()
+	status, hndl, auths = h.Handler.Mount(ctx, conn, req)
+	if hndl != nil {
+		hndl = &recoveryFilesystem{Filesystem: hndl, onPanic: h.onPanic}
+	}
+	return
+}
+
+func (h *recoveryHandler) Change(fs billy.Filesystem) billy.Change {
+	defer h.recover()
+	// If fs is our wrapped fs, unwrap it for the underlying handler
+	if rf, ok := fs.(*recoveryFilesystem); ok {
+		fs = rf.Filesystem
+	}
+	return h.Handler.Change(fs)
+}
+
+func (h *recoveryHandler) FSStat(ctx context.Context, fs billy.Filesystem, stat *nfs.FSStat) error {
+	defer h.recover()
+	if rf, ok := fs.(*recoveryFilesystem); ok {
+		fs = rf.Filesystem
+	}
+	return h.Handler.FSStat(ctx, fs, stat)
+}
+
+func (h *recoveryHandler) ToHandle(fs billy.Filesystem, path []string) []byte {
+	defer h.recover()
+	if rf, ok := fs.(*recoveryFilesystem); ok {
+		fs = rf.Filesystem
+	}
+	return h.Handler.ToHandle(fs, path)
+}
+
+func (h *recoveryHandler) FromHandle(fh []byte) (billy.Filesystem, []string, error) {
+	defer h.recover()
+	fs, path, err := h.Handler.FromHandle(fh)
+	if fs != nil {
+		fs = &recoveryFilesystem{Filesystem: fs, onPanic: h.onPanic}
+	}
+	return fs, path, err
+}
+
+func (h *recoveryHandler) InvalidateHandle(fs billy.Filesystem, fh []byte) error {
+	defer h.recover()
+	if rf, ok := fs.(*recoveryFilesystem); ok {
+		fs = rf.Filesystem
+	}
+	return h.Handler.InvalidateHandle(fs, fh)
+}
+
+func (h *recoveryHandler) HandleLimit() int {
+	defer h.recover()
+	return h.Handler.HandleLimit()
+}
+
+// recoveryFilesystem wraps a billy.Filesystem with panic recovery.
+// It uses explicit delegation (not embedding) so the compiler forces
+// us to implement any new methods added to the interface.
+type recoveryFilesystem struct {
+	Filesystem billy.Filesystem
+	onPanic    OnPanic
+}
+
+func (fs *recoveryFilesystem) recover() {
+	if r := recover(); r != nil {
+		fs.onPanic(r)
+	}
+}
+
+func (fs *recoveryFilesystem) Create(filename string) (billy.File, error) {
+	defer fs.recover()
+	return fs.Filesystem.Create(filename)
+}
+
+func (fs *recoveryFilesystem) Open(filename string) (billy.File, error) {
+	defer fs.recover()
+	return fs.Filesystem.Open(filename)
+}
+
+func (fs *recoveryFilesystem) OpenFile(filename string, flag int, perm os.FileMode) (billy.File, error) {
+	defer fs.recover()
+	return fs.Filesystem.OpenFile(filename, flag, perm)
+}
+
+func (fs *recoveryFilesystem) Stat(filename string) (os.FileInfo, error) {
+	defer fs.recover()
+	return fs.Filesystem.Stat(filename)
+}
+
+func (fs *recoveryFilesystem) Rename(oldpath, newpath string) error {
+	defer fs.recover()
+	return fs.Filesystem.Rename(oldpath, newpath)
+}
+
+func (fs *recoveryFilesystem) Remove(filename string) error {
+	defer fs.recover()
+	return fs.Filesystem.Remove(filename)
+}
+
+func (fs *recoveryFilesystem) Join(elem ...string) string {
+	defer fs.recover()
+	return fs.Filesystem.Join(elem...)
+}
+
+func (fs *recoveryFilesystem) TempFile(dir, prefix string) (billy.File, error) {
+	defer fs.recover()
+	return fs.Filesystem.TempFile(dir, prefix)
+}
+
+func (fs *recoveryFilesystem) ReadDir(path string) ([]os.FileInfo, error) {
+	defer fs.recover()
+	return fs.Filesystem.ReadDir(path)
+}
+
+func (fs *recoveryFilesystem) MkdirAll(filename string, perm os.FileMode) error {
+	defer fs.recover()
+	return fs.Filesystem.MkdirAll(filename, perm)
+}
+
+func (fs *recoveryFilesystem) Lstat(filename string) (os.FileInfo, error) {
+	defer fs.recover()
+	return fs.Filesystem.Lstat(filename)
+}
+
+func (fs *recoveryFilesystem) Symlink(target, link string) error {
+	defer fs.recover()
+	return fs.Filesystem.Symlink(target, link)
+}
+
+func (fs *recoveryFilesystem) Readlink(link string) (string, error) {
+	defer fs.recover()
+	return fs.Filesystem.Readlink(link)
+}
+
+func (fs *recoveryFilesystem) Chroot(path string) (billy.Filesystem, error) {
+	defer fs.recover()
+	bfs, err := fs.Filesystem.Chroot(path)
+	if bfs != nil {
+		bfs = &recoveryFilesystem{Filesystem: bfs, onPanic: fs.onPanic}
+	}
+	return bfs, err
+}
+
+func (fs *recoveryFilesystem) Root() string {
+	defer fs.recover()
+	return fs.Filesystem.Root()
+}

--- a/helpers/recovery_test.go
+++ b/helpers/recovery_test.go
@@ -1,0 +1,60 @@
+package helpers
+
+import (
+	"context"
+	"net"
+	"os"
+	"testing"
+
+	"github.com/go-git/go-billy/v6"
+	"github.com/go-git/go-billy/v6/memfs"
+	"github.com/treeverse/go-nfs"
+)
+
+type panicHandler struct {
+	NullAuthHandler
+}
+
+func (h *panicHandler) Mount(ctx context.Context, conn net.Conn, req nfs.MountRequest) (nfs.MountStatus, billy.Filesystem, []nfs.AuthFlavor) {
+	panic("mount panic")
+}
+
+func TestRecoverPanics(t *testing.T) {
+	fs := memfs.New()
+	handler := &panicHandler{NullAuthHandler{fs}}
+
+	var panicked any
+	wrapped := RecoverPanics(handler, func(r any) {
+		panicked = r
+	})
+
+	_, _, _ = wrapped.Mount(context.Background(), nil, nfs.MountRequest{})
+	if panicked != "mount panic" {
+		t.Errorf("expected panic 'mount panic', got %v", panicked)
+	}
+}
+
+type panicFS struct {
+	billy.Filesystem
+}
+
+func (fs *panicFS) Stat(path string) (os.FileInfo, error) {
+	panic("stat panic")
+}
+
+func TestRecoverPanicsFS(t *testing.T) {
+	fs := &panicFS{memfs.New()}
+	handler := NewNullAuthHandler(fs)
+
+	var panicked any
+	wrapped := RecoverPanics(handler, func(r any) {
+		panicked = r
+	})
+
+	_, wrappedFS, _ := wrapped.Mount(context.Background(), nil, nfs.MountRequest{})
+	_, _ = wrappedFS.Stat("foo")
+
+	if panicked != "stat panic" {
+		t.Errorf("expected panic 'stat panic', got %v", panicked)
+	}
+}


### PR DESCRIPTION
Adds a `RecoverPanics` wrapper that interposes on an `nfs.Handler` and the underlying `billy.Filesystem` to recover from panics in both the handler methods and filesystem operations.

This is a wrapper-only approach as suggested by the upstream maintainer, providing a composable way to add panic recovery without modifying the core library.

## Usage



The wrapper:
- Wraps all `nfs.Handler` method calls with `recover()`
- Wraps the `billy.Filesystem` returned by `Mount` and `FromHandle` so filesystem implementation panics are also caught
- Unwraps the filesystem when passing it back to the underlying handler to avoid double-wrapping

## Testing

Unit tests verify that panics in both handler methods and filesystem operations are correctly recovered and reported to the provided callback.
