### PR TITLE
fix: report unhandled errors as NFS SERVERFAULT, not an RPC fault

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -154,14 +154,16 @@ func (r *ResponseCodeSystemError) MarshalBinary() (data []byte, err error) {
 }
 
 // basicErrorFormatter is the default error handler for response errors.
-// if the error is already formatted, it is directly written. Otherwise,
-// ResponseCodeSystemError is sent to the client.
+// If the error is already formatted, it is directly written.  An unrecognized
+// error is reported as the NFS status SERVERFAULT inside an accepted reply, not
+// as an RPC-level fault: an RPC fault means the request itself was malformed,
+// which some clients (macOS reports EBADRPC) turn into a failed syscall.
 func basicErrorFormatter(err error) RPCError {
 	var rpcErr RPCError
 	if errors.As(err, &rpcErr) {
 		return rpcErr
 	}
-	return &ResponseCodeSystemError{}
+	return &NFSStatusError{NFSStatus: NFSStatusServerFault}
 }
 
 // NFSStatusError represents an error at the NFS level.
@@ -218,7 +220,7 @@ func errFormatterWithBody(body []byte) func(err error) RPCError {
 		if errors.As(err, &rErr) {
 			return rErr
 		}
-		return &ResponseCodeSystemError{}
+		return &StatusErrorWithBody{NFSStatusError{NFSStatus: NFSStatusServerFault}, body[:]}
 	}
 }
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,42 @@
+package nfs
+
+import (
+	"encoding/binary"
+	"errors"
+	"testing"
+)
+
+// A handler or filesystem error that go-nfs does not recognize must be reported
+// to the client as an NFS-level status inside a normal accepted reply, never as
+// an RPC-level accept_stat fault.  An RPC fault is read by some clients (notably
+// macOS, as EBADRPC) as a hard protocol error, turning a transient server-side
+// failure into a failed syscall.
+func TestUnknownErrorMapsToNFSStatusNotRPCFault(t *testing.T) {
+	unknown := errors.New("save chunks: predicate failed")
+
+	for _, tc := range []struct {
+		name      string
+		formatter func(error) RPCError
+	}{
+		{"basic", basicErrorFormatter},
+		{"wccData", wccDataErrorFormatter},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rpcErr := tc.formatter(unknown)
+
+			if rpcErr.Code() != ResponseCodeSuccess {
+				t.Fatalf("unknown error must be an accepted NFS-level reply (ResponseCodeSuccess), got RPC code %d", rpcErr.Code())
+			}
+			body, err := rpcErr.MarshalBinary()
+			if err != nil {
+				t.Fatalf("MarshalBinary: %v", err)
+			}
+			if len(body) < 4 {
+				t.Fatalf("expected an NFS status in the reply body, got %d bytes", len(body))
+			}
+			if status := NFSStatus(binary.BigEndian.Uint32(body[:4])); status != NFSStatusServerFault {
+				t.Fatalf("expected NFS status SERVERFAULT (%d), got %d", NFSStatusServerFault, status)
+			}
+		})
+	}
+}


### PR DESCRIPTION
An error a procedure handler returns that is neither an RPCError nor an NFSStatusError was formatted as ResponseCodeSystemError, an RPC-level accept_stat fault.  A fault signals a malformed RPC, which some clients (macOS surfaces it as EBADRPC) turn into a failed syscall rather than a normal filesystem error.

Map such errors to the NFS status SERVERFAULT inside an accepted reply so the client receives an ordinary I/O error instead.